### PR TITLE
Fail to add submodule alloy due to .gitignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Enter the alloy-gui directory:
 
 Download the latest alloycoin codebase:
 
-```git submodule add https://github.com/alloy-project/alloy```
+```git submodule add -f https://github.com/alloy-project/alloy```
 
 Create a build directory and enter it:
 


### PR DESCRIPTION
## Issue details
```
imac:Projects kh4n$ git clone https://github.com/alloy-project/alloy-gui
Cloning into 'alloy-gui'...
remote: Counting objects: 815, done.
remote: Compressing objects: 100% (395/395), done.
remote: Total 815 (delta 461), reused 761 (delta 419), pack-reused 0
Receiving objects: 100% (815/815), 1.24 MiB | 292.00 KiB/s, done.
Resolving deltas: 100% (461/461), done.
imac:Projects kh4n$ cd alloy-gui/
imac:alloy-gui kh4n$ git submodule add https://github.com/alloy-project/alloy
Cloning into '/Users/kh4n/Projects/alloy-gui/alloy'...
remote: Counting objects: 3967, done.
remote: Compressing objects: 100% (1871/1871), done.
remote: Total 3967 (delta 1055), reused 2075 (delta 865), pack-reused 1172
Receiving objects: 100% (3967/3967), 10.65 MiB | 334.00 KiB/s, done.
Resolving deltas: 100% (1400/1400), done.
The following paths are ignored by one of your .gitignore files:
alloy
Use -f if you really want to add them.
Failed to add submodule 'alloy'
```

## Proposed solution
I suggest updating build docs to `git submodule add -f https://github.com/alloy-project/alloy`